### PR TITLE
Migrate to ESLint flat config (eslint-config-domdomegg v2)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,6 @@
+import domdomegg from 'eslint-config-domdomegg';
+
+/** @type {import('@typescript-eslint/utils').TSESLint.FlatConfig.ConfigFile} */
+export default [
+	...domdomegg,
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
       "devDependencies": {
         "@tsconfig/node-lts": "^22.0.1",
         "@tsconfig/strictest": "^2.0.5",
-        "eslint": "^8.56.0",
-        "eslint-config-domdomegg": "^1.2.3",
+        "eslint": "^9.0.0",
+        "eslint-config-domdomegg": "^2.0.9",
         "typescript": "^5.8.2",
         "vitest": "^3.0.7"
       }
@@ -451,9 +451,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
-      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -469,33 +469,12 @@
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
-    "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^9.6.0",
-        "globals": "^13.19.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
+      "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -503,30 +482,154 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/js": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
-    "node_modules/@humanwhocodes/config-array": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
-      "deprecated": "Use @eslint/config-array instead",
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.3",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.0.5"
+        "minimatch": "^3.1.5"
       },
       "engines": {
-        "node": ">=10.10.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -543,13 +646,19 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-      "deprecated": "Use @eslint/object-schema instead",
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
@@ -557,44 +666,6 @@
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.34.9",
@@ -862,19 +933,25 @@
         "win32"
       ]
     },
-    "node_modules/@rtsao/scc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
-      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.13.0.tgz",
+      "integrity": "sha512-RnO1SaiCFHn666wNz2QfZEFxvmiNRqhzaMXHXxXXKt+MEP7aajlPxUSMIQpKAaJfverpovEYqjBOXDq6dDcaOQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@rushstack/eslint-patch": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.5.tgz",
-      "integrity": "sha512-kkKUDVlII2DQiKy7UstOR1ErJP8kUKAQ4oa+SQtM0K+lPdmmjj0YnnxBgtTVYH7mUKtbsxeFC9y0AmK7Yb78/A==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.13.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
     },
     "node_modules/@tsconfig/node-lts": {
       "version": "22.0.1",
@@ -904,13 +981,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "22.13.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
@@ -935,132 +1005,160 @@
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
     },
-    "node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
-      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
+      "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/type-utils": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
-        "debug": "^4.3.4",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/type-utils": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-        "eslint": "^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "@typescript-eslint/parser": "^8.63.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
+      "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
+        "debug": "^4.4.3"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+      "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.63.0",
+        "@typescript-eslint/types": "^8.63.0",
+        "debug": "^4.4.3"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+      "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0"
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
-      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+      "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^1.0.1"
-      },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
+      "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+      "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1068,110 +1166,126 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+      "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "@typescript-eslint/project-service": "8.63.0",
+        "@typescript-eslint/tsconfig-utils": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "eslint-visitor-keys": "^3.4.1"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
+      "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+      "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.63.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
-      "license": "ISC"
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "3.0.7",
@@ -1287,9 +1401,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1310,9 +1424,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1324,16 +1438,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -1407,41 +1511,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/array.prototype.findlast": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
       "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.findlastindex": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz",
-      "integrity": "sha512-zfETvRFA8o7EiNn++N5f/kaCw221hrpGsDmcpndVupkPzEc1Wuf3VgC0qby1BbHs7f5DVYjgtEU2LLh5bqeGfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1632,19 +1705,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/cac": {
@@ -1883,9 +1943,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1960,32 +2020,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/dunder-proto": {
@@ -2241,266 +2275,137 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
-      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
-      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.1",
-        "@humanwhocodes/config-array": "^0.13.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@nodelib/fs.walk": "^1.2.8",
-        "@ungap/structured-clone": "^1.2.0",
-        "ajv": "^6.12.4",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
+        "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.3",
-        "espree": "^9.6.1",
-        "esquery": "^1.4.2",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
+        "file-entry-cache": "^8.0.0",
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
-        "globals": "^13.19.0",
-        "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
+        "optionator": "^0.9.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-config-airbnb": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz",
-      "integrity": "sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-config-airbnb-base": "^15.0.0",
-        "object.assign": "^4.1.2",
-        "object.entries": "^1.1.5"
-      },
-      "engines": {
-        "node": "^10.12.0 || ^12.22.0 || ^14.17.0 || >=16.0.0"
+        "url": "https://eslint.org/donate"
       },
       "peerDependencies": {
-        "eslint": "^7.32.0 || ^8.2.0",
-        "eslint-plugin-import": "^2.25.3",
-        "eslint-plugin-jsx-a11y": "^6.5.1",
-        "eslint-plugin-react": "^7.28.0",
-        "eslint-plugin-react-hooks": "^4.3.0"
-      }
-    },
-    "node_modules/eslint-config-airbnb-base": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
-      "integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "confusing-browser-globals": "^1.0.10",
-        "object.assign": "^4.1.2",
-        "object.entries": "^1.1.5",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^7.32.0 || ^8.2.0",
-        "eslint-plugin-import": "^2.25.2"
-      }
-    },
-    "node_modules/eslint-config-airbnb-base/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/eslint-config-airbnb-typescript": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-17.1.0.tgz",
-      "integrity": "sha512-GPxI5URre6dDpJ0CtcthSZVBAfI+Uw7un5OYNVxP2EYi3H81Jw701yFP7AU+/vCE7xBtFmjge7kfhhk4+RAiig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-config-airbnb-base": "^15.0.0"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.13.0 || ^6.0.0",
-        "@typescript-eslint/parser": "^5.0.0 || ^6.0.0",
-        "eslint": "^7.32.0 || ^8.2.0",
-        "eslint-plugin-import": "^2.25.3"
-      }
-    },
-    "node_modules/eslint-config-domdomegg": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-config-domdomegg/-/eslint-config-domdomegg-1.2.3.tgz",
-      "integrity": "sha512-OkVoSxctmpkF63vze8RHGvHMW8dijzI2k2s1mTLYMWHCDWGhabr+IToB+uT0w6AsoIN59yps6uhHK2iBJ2Y3AA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rushstack/eslint-patch": "^1.6.0",
-        "@typescript-eslint/eslint-plugin": "^6.13.2",
-        "@typescript-eslint/parser": "^6.13.2",
-        "eslint-config-airbnb": "^19.0.4",
-        "eslint-config-airbnb-typescript": "^17.1.0",
-        "eslint-plugin-import": "^2.29.0",
-        "eslint-plugin-jsx-a11y": "^6.8.0",
-        "eslint-plugin-react": "^7.33.2",
-        "eslint-plugin-react-hooks": "^4.6.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.55.0"
-      }
-    },
-    "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
-      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.7",
-        "is-core-module": "^2.13.0",
-        "resolve": "^1.22.4"
-      }
-    },
-    "node_modules/eslint-import-resolver-node/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-module-utils": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz",
-      "integrity": "sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.7"
-      },
-      "engines": {
-        "node": ">=4"
+        "jiti": "*"
       },
       "peerDependenciesMeta": {
-        "eslint": {
+        "jiti": {
           "optional": true
         }
       }
     },
-    "node_modules/eslint-module-utils/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+    "node_modules/eslint-config-domdomegg": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/eslint-config-domdomegg/-/eslint-config-domdomegg-2.0.9.tgz",
+      "integrity": "sha512-VjGMmqmIZ+U8HgbxxzoVEkcyXjeOqcd02sQaiD+g3V7wFuQAKcP6Mqr/mrBRfaXGRu62fsCC2uEOgr/VHzz7iw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-plugin-import": {
-      "version": "2.31.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
-      "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rtsao/scc": "^1.1.0",
-        "array-includes": "^3.1.8",
-        "array.prototype.findlastindex": "^1.2.5",
-        "array.prototype.flat": "^1.3.2",
-        "array.prototype.flatmap": "^1.3.2",
-        "debug": "^3.2.7",
-        "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.9",
-        "eslint-module-utils": "^2.12.0",
-        "hasown": "^2.0.2",
-        "is-core-module": "^2.15.1",
-        "is-glob": "^4.0.3",
-        "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.8",
-        "object.groupby": "^1.0.3",
-        "object.values": "^1.2.0",
-        "semver": "^6.3.1",
-        "string.prototype.trimend": "^1.0.8",
-        "tsconfig-paths": "^3.15.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "@eslint/js": "^9.19.0",
+        "eslint-config-xo-typescript": "^7.0.0",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
+        "eslint-plugin-react": "^7.37.4",
+        "eslint-plugin-react-hooks": "^5.1.0",
+        "typescript-eslint": "^8.22.0"
       },
       "peerDependencies": {
-        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+        "eslint": "^9"
       }
     },
-    "node_modules/eslint-plugin-import/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+    "node_modules/eslint-config-xo": {
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.46.0.tgz",
+      "integrity": "sha512-mjQUhdTCLQwHUFKf1hhSx1FFhm2jllr4uG2KjaW7gZHGAbjKoSypvo1eQvFk17lHx3bztYjZDDXQmkAZyaSlAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "esutils": "^2.0.2"
+        "@stylistic/eslint-plugin": "^2.6.1",
+        "confusing-browser-globals": "1.0.11",
+        "globals": "^15.3.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=18.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.8.0"
       }
     },
-    "node_modules/eslint-plugin-import/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+    "node_modules/eslint-config-xo-typescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-7.0.0.tgz",
+      "integrity": "sha512-Mvy5eo6PW2BWPpxLsG7Y28LciZhLhiXFZAw/H3kdia34Efudk2aWMWwAKqkEFamo/SHiyMYkqUx6DYO+YJeVVg==",
       "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
+      "license": "MIT",
+      "dependencies": {
+        "@stylistic/eslint-plugin": "^2.6.1",
+        "eslint-config-xo": "^0.46.0",
+        "typescript-eslint": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.8.0",
+        "typescript": ">=5.5.0"
+      }
+    },
+    "node_modules/eslint-config-xo/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {
@@ -2567,16 +2472,16 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
-      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
@@ -2621,9 +2526,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2631,38 +2536,38 @@
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.9.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -2741,36 +2646,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2785,40 +2660,35 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^3.0.4"
+        "flat-cache": "^4.0.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/find-up": {
@@ -2839,24 +2709,23 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
-      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
-        "keyv": "^4.5.3",
-        "rimraf": "^3.0.2"
+        "keyv": "^4.5.4"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2910,13 +2779,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -3028,28 +2890,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3064,16 +2904,13 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3096,27 +2933,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3128,13 +2944,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -3263,25 +3072,6 @@
       "engines": {
         "node": ">=0.8.19"
       }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -3504,16 +3294,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/is-number-object": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
@@ -3529,16 +3309,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-regex": {
@@ -3726,10 +3496,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3758,19 +3538,6 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
@@ -3894,30 +3661,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -3940,9 +3683,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3950,16 +3693,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {
@@ -4083,21 +3816,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object.groupby": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
-      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/object.values": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
@@ -4115,16 +3833,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
       }
     },
     "node_modules/optionator": {
@@ -4236,16 +3944,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -4262,16 +3960,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -4298,13 +3986,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -4387,27 +4075,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -4459,27 +4126,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.16.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -4497,34 +4143,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rollup": {
@@ -4564,30 +4182,6 @@
         "@rollup/rollup-win32-ia32-msvc": "4.34.9",
         "@rollup/rollup-win32-x64-msvc": "4.34.9",
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-array-concat": {
@@ -4646,9 +4240,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4813,16 +4407,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4960,29 +4544,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -5022,13 +4583,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -5042,6 +4596,23 @@
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
     },
     "node_modules/tinypool": {
       "version": "1.0.2",
@@ -5073,43 +4644,17 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/ts-api-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18.12"
       },
       "peerDependencies": {
-        "typescript": ">=4.2.0"
-      }
-    },
-    "node_modules/tsconfig-paths": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
-      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.2",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/type-check": {
@@ -5123,19 +4668,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -5228,6 +4760,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.63.0.tgz",
+      "integrity": "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.63.0",
+        "@typescript-eslint/parser": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -5560,13 +5116,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "npm run build && node --env-file=.env dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest --watch",
-    "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
+    "lint": "eslint",
     "clean": "rm -rf dist",
     "build": "tsc --project tsconfig.build.json",
     "prepublishOnly": "npm run clean && npm run build"
@@ -25,15 +25,10 @@
   "devDependencies": {
     "@tsconfig/node-lts": "^22.0.1",
     "@tsconfig/strictest": "^2.0.5",
-    "eslint": "^8.56.0",
-    "eslint-config-domdomegg": "^1.2.3",
+    "eslint": "^9.0.0",
+    "eslint-config-domdomegg": "^2.0.9",
     "typescript": "^5.8.2",
     "vitest": "^3.0.7"
-  },
-  "eslintConfig": {
-    "extends": [
-      "eslint-config-domdomegg"
-    ]
   },
   "dependencies": {
     "@types/node": "^22.13.9",

--- a/src/addTypo.test.ts
+++ b/src/addTypo.test.ts
@@ -1,70 +1,70 @@
 import {
-  describe, test, expect, beforeEach, vi, MockInstance,
+	describe, test, expect, beforeEach, vi, type MockInstance,
 } from 'vitest';
-import { addTypo } from './addTypo';
+import {addTypo} from './addTypo';
 
 describe('addTypo', () => {
-  let mathRandomSpy: MockInstance;
+	let mathRandomSpy: MockInstance;
 
-  beforeEach(() => {
-    // Reset Math.random mock before each test
-    if (mathRandomSpy) {
-      mathRandomSpy.mockRestore();
-    }
-  });
+	beforeEach(() => {
+		// Reset Math.random mock before each test
+		if (mathRandomSpy) {
+			mathRandomSpy.mockRestore();
+		}
+	});
 
-  test('handles single character string', () => {
-    mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0); // Force TRANSPOSITION
-    expect(addTypo('a')).toBe('a');
-  });
+	test('handles single character string', () => {
+		mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0); // Force TRANSPOSITION
+		expect(addTypo('a')).toBe('a');
+	});
 
-  test('performs TRANSPOSITION typo', () => {
-    mathRandomSpy = vi.spyOn(Math, 'random')
-      .mockReturnValueOnce(0) // Select TRANSPOSITION type
-      .mockReturnValueOnce(0); // Select first character
-    expect(addTypo('hello')).toBe('ehllo');
-  });
+	test('performs TRANSPOSITION typo', () => {
+		mathRandomSpy = vi.spyOn(Math, 'random')
+			.mockReturnValueOnce(0) // Select TRANSPOSITION type
+			.mockReturnValueOnce(0); // Select first character
+		expect(addTypo('hello')).toBe('ehllo');
+	});
 
-  test('performs TRANSPOSITION at end of string', () => {
-    mathRandomSpy = vi.spyOn(Math, 'random')
-      .mockReturnValueOnce(0) // Select TRANSPOSITION type
-      .mockReturnValueOnce(0.99); // Force last character selection
-    expect(addTypo('hello')).toBe('helol');
-  });
+	test('performs TRANSPOSITION at end of string', () => {
+		mathRandomSpy = vi.spyOn(Math, 'random')
+			.mockReturnValueOnce(0) // Select TRANSPOSITION type
+			.mockReturnValueOnce(0.99); // Force last character selection
+		expect(addTypo('hello')).toBe('helol');
+	});
 
-  test('performs OMISSION typo', () => {
-    mathRandomSpy = vi.spyOn(Math, 'random')
-      .mockReturnValueOnce(0.2) // Select OMISSION type
-      .mockReturnValueOnce(0); // Select first character
-    expect(addTypo('hello')).toBe('ello');
-  });
+	test('performs OMISSION typo', () => {
+		mathRandomSpy = vi.spyOn(Math, 'random')
+			.mockReturnValueOnce(0.2) // Select OMISSION type
+			.mockReturnValueOnce(0); // Select first character
+		expect(addTypo('hello')).toBe('ello');
+	});
 
-  test('performs DOUBLING typo', () => {
-    mathRandomSpy = vi.spyOn(Math, 'random')
-      .mockReturnValueOnce(0.4) // Select DOUBLING type
-      .mockReturnValueOnce(0); // Select first character
-    expect(addTypo('hello')).toBe('hhello');
-  });
+	test('performs DOUBLING typo', () => {
+		mathRandomSpy = vi.spyOn(Math, 'random')
+			.mockReturnValueOnce(0.4) // Select DOUBLING type
+			.mockReturnValueOnce(0); // Select first character
+		expect(addTypo('hello')).toBe('hhello');
+	});
 
-  test('performs SUBSTITUTION typo', () => {
-    mathRandomSpy = vi.spyOn(Math, 'random')
-      .mockReturnValueOnce(0.6) // Select SUBSTITUTION type
-      .mockReturnValueOnce(0) // Select first character
-      .mockReturnValueOnce(0); // Select first substitution option
-    expect(addTypo('hello')).toBe('yello'); // 'h' is replaced with 'y' (first option in commonLetterSubstitutions['h'])
-  });
+	test('performs SUBSTITUTION typo', () => {
+		mathRandomSpy = vi.spyOn(Math, 'random')
+			.mockReturnValueOnce(0.6) // Select SUBSTITUTION type
+			.mockReturnValueOnce(0) // Select first character
+			.mockReturnValueOnce(0); // Select first substitution option
+		expect(addTypo('hello')).toBe('yello'); // 'h' is replaced with 'y' (first option in commonLetterSubstitutions['h'])
+	});
 
-  test('performs CAPITALIZATION typo', () => {
-    mathRandomSpy = vi.spyOn(Math, 'random')
-      .mockReturnValueOnce(0.8) // Select CAPITALIZATION type
-      .mockReturnValueOnce(0); // Select first character
-    expect(addTypo('hello')).toBe('Hello');
-  });
+	test('performs CAPITALIZATION typo', () => {
+		mathRandomSpy = vi.spyOn(Math, 'random')
+			.mockReturnValueOnce(0.8) // Select CAPITALIZATION type
+			.mockReturnValueOnce(0); // Select first character
+		expect(addTypo('hello')).toBe('Hello');
+	});
 
-  test('performs CAPITALIZATION typo on already capitalized letter', () => {
-    mathRandomSpy = vi.spyOn(Math, 'random')
-      .mockReturnValueOnce(0.8) // Select CAPITALIZATION type
-      .mockReturnValueOnce(0); // Select first character
-    expect(addTypo('Hello')).toBe('hello');
-  });
+	test('performs CAPITALIZATION typo on already capitalized letter', () => {
+		mathRandomSpy = vi.spyOn(Math, 'random')
+			.mockReturnValueOnce(0.8) // Select CAPITALIZATION type
+			.mockReturnValueOnce(0); // Select first character
+		expect(addTypo('Hello')).toBe('hello');
+	});
 });

--- a/src/addTypo.ts
+++ b/src/addTypo.ts
@@ -1,107 +1,110 @@
 const typoTypes = [
-  /** Switching two adjacent letters */
-  'TRANSPOSITION',
-  /** Removing a letter */
-  'OMISSION',
-  /** Copying an adjacent letter */
-  'DOUBLING',
-  /** Replacing a letter */
-  'SUBSTITUTION',
-  /** Swapping letter case */
-  'CAPITALIZATION',
+	/** Switching two adjacent letters */
+	'TRANSPOSITION',
+	/** Removing a letter */
+	'OMISSION',
+	/** Copying an adjacent letter */
+	'DOUBLING',
+	/** Replacing a letter */
+	'SUBSTITUTION',
+	/** Swapping letter case */
+	'CAPITALIZATION',
 ] as const;
 
 export const addTypo = (s: string): string => {
-  const typoType = typoTypes[Math.floor(Math.random() * typoTypes.length)]!;
+	const typoType = typoTypes[Math.floor(Math.random() * typoTypes.length)]!;
 
-  const randomIndex = Math.floor(Math.random() * s.length);
-  switch (typoType) {
-    case 'TRANSPOSITION': {
-      if (s.length < 2) {
-        return s;
-      }
-      if (randomIndex === s.length - 1) {
-        return s.slice(0, -2) + s[s.length - 1] + s[s.length - 2];
-      }
-      return s.slice(0, randomIndex) + s[randomIndex + 1] + s[randomIndex] + s.slice(randomIndex + 2);
-    }
-    case 'OMISSION': {
-      return s.slice(0, randomIndex) + s.slice(randomIndex + 1);
-    }
-    case 'DOUBLING': {
-      return s.slice(0, randomIndex) + s[randomIndex] + s.slice(randomIndex);
-    }
-    case 'SUBSTITUTION': {
-      return s.slice(0, randomIndex) + getSubstitution(s[randomIndex]!) + s.slice(randomIndex + 1);
-    }
-    case 'CAPITALIZATION': {
-      const letter = s[randomIndex]!;
-      const flippedCapitalization = letter === letter.toUpperCase() ? letter.toLowerCase() : letter.toUpperCase();
-      return s.slice(0, randomIndex) + flippedCapitalization + s.slice(randomIndex + 1);
-    }
-    default: {
-      throw new Error(`Unknown ${typoType satisfies never}`);
-    }
-  }
+	const randomIndex = Math.floor(Math.random() * s.length);
+	switch (typoType) {
+		case 'TRANSPOSITION': {
+			if (s.length < 2) {
+				return s;
+			}
+
+			if (randomIndex === s.length - 1) {
+				return s.slice(0, -2) + s[s.length - 1] + s[s.length - 2];
+			}
+
+			return s.slice(0, randomIndex) + s[randomIndex + 1] + s[randomIndex] + s.slice(randomIndex + 2);
+		}
+
+		case 'OMISSION': {
+			return s.slice(0, randomIndex) + s.slice(randomIndex + 1);
+		}
+
+		case 'DOUBLING': {
+			return s.slice(0, randomIndex) + s[randomIndex] + s.slice(randomIndex);
+		}
+
+		case 'SUBSTITUTION': {
+			return s.slice(0, randomIndex) + getSubstitution(s[randomIndex]!) + s.slice(randomIndex + 1);
+		}
+
+		case 'CAPITALIZATION': {
+			const letter = s[randomIndex]!;
+			const flippedCapitalization = letter === letter.toUpperCase() ? letter.toLowerCase() : letter.toUpperCase();
+			return s.slice(0, randomIndex) + flippedCapitalization + s.slice(randomIndex + 1);
+		}
+	}
 };
 
 const commonLetterSubstitutions: Record<string, string> = {
-  q: '12wa',
-  w: '3eqr',
-  e: '4wrd',
-  r: '5tef',
-  t: '6ygr',
-  y: '7uhj',
-  u: '8ijk',
-  i: '9olm',
-  o: '0pk',
-  p: 'lo[',
-  '[': 'p;',
-  ']': ';\'',
-  '\\': '\'',
-  a: 'qzs',
-  s: 'wedxz',
-  d: 'rfcxs',
-  f: 'rvgtc',
-  g: 'tfbv',
-  h: 'ygbn',
-  j: 'uikmn',
-  k: 'iolm,',
-  l: 'op;,.',
-  ';': 'lk/',
-  '\'': ']\\',
-  z: 'asx',
-  x: 'zsdc',
-  c: 'xdfv',
-  v: 'cfgb',
-  b: 'vghn',
-  n: 'hjm,',
-  m: 'jkn,',
-  ',': 'km?',
-  1: '2q!',
-  2: '3wq@',
-  3: '4er#',
-  4: '5t$',
-  5: '6y%',
-  6: '7ui^',
-  7: '8yo&',
-  8: '9i(*',
-  9: '0o)',
-  0: 'p-_',
-  '-': '0=+',
-  '=': '-',
+	q: '12wa',
+	w: '3eqr',
+	e: '4wrd',
+	r: '5tef',
+	t: '6ygr',
+	y: '7uhj',
+	u: '8ijk',
+	i: '9olm',
+	o: '0pk',
+	p: 'lo[',
+	'[': 'p;',
+	']': ';\'',
+	'\\': '\'',
+	a: 'qzs',
+	s: 'wedxz',
+	d: 'rfcxs',
+	f: 'rvgtc',
+	g: 'tfbv',
+	h: 'ygbn',
+	j: 'uikmn',
+	k: 'iolm,',
+	l: 'op;,.',
+	';': 'lk/',
+	'\'': ']\\',
+	z: 'asx',
+	x: 'zsdc',
+	c: 'xdfv',
+	v: 'cfgb',
+	b: 'vghn',
+	n: 'hjm,',
+	m: 'jkn,',
+	',': 'km?',
+	1: '2q!',
+	2: '3wq@',
+	3: '4er#',
+	4: '5t$',
+	5: '6y%',
+	6: '7ui^',
+	7: '8yo&',
+	8: '9i(*',
+	9: '0o)',
+	0: 'p-_',
+	'-': '0=+',
+	'=': '-',
 };
 
 const getSubstitution = (letter: string): string => {
-  if (letter.length !== 1) {
-    throw new Error(`Expected single letter input, but got input of length ${letter.length}`);
-  }
+	if (letter.length !== 1) {
+		throw new Error(`Expected single letter input, but got input of length ${letter.length}`);
+	}
 
-  const lookup = commonLetterSubstitutions[letter];
-  if (lookup) {
-    return lookup[Math.floor(Math.random() * lookup.length)]!;
-  }
+	const lookup = commonLetterSubstitutions[letter];
+	if (lookup) {
+		return lookup[Math.floor(Math.random() * lookup.length)]!;
+	}
 
-  const allKeys = Object.keys(commonLetterSubstitutions);
-  return allKeys[Math.floor(Math.random() * allKeys.length)]!;
+	const allKeys = Object.keys(commonLetterSubstitutions);
+	return allKeys[Math.floor(Math.random() * allKeys.length)]!;
 };

--- a/src/dataset-connectors/interface.ts
+++ b/src/dataset-connectors/interface.ts
@@ -1,8 +1,8 @@
 export type EvaluationQuestion = {
-  id: string,
-  prompt: string,
-  answer: string,
-  choices: string[],
+	id: string;
+	prompt: string;
+	answer: string;
+	choices: string[];
 };
 
 export type EvaluationQuestionProvider = (fn: (q: EvaluationQuestion) => Promise<void>) => Promise<void>;

--- a/src/dataset-connectors/mmlu/config.ts
+++ b/src/dataset-connectors/mmlu/config.ts
@@ -1,10 +1,10 @@
-import { resolve } from 'path';
+import {resolve} from 'path';
 
 export const config = {
-  // Download from one of:
-  // https://huggingface.co/datasets/cais/mmlu/resolve/main/data.tar?download=true
-  // https://people.eecs.berkeley.edu/~hendrycks/data.tar
-  //
-  // This folder should have dev and test folders within it
-  pathToFolder: resolve(process.env['DATASET_MMLU_FOLDER']!),
+	// Download from one of:
+	// https://huggingface.co/datasets/cais/mmlu/resolve/main/data.tar?download=true
+	// https://people.eecs.berkeley.edu/~hendrycks/data.tar
+	//
+	// This folder should have dev and test folders within it
+	pathToFolder: resolve(process.env['DATASET_MMLU_FOLDER']!),
 };

--- a/src/dataset-connectors/mmlu/index.ts
+++ b/src/dataset-connectors/mmlu/index.ts
@@ -1,82 +1,86 @@
 import Papa from 'papaparse';
-import { createReadStream, readFileSync, readdirSync } from 'fs';
-import { join } from 'path';
-import { EvaluationQuestionProvider } from '../interface';
-import { config } from './config';
+import {createReadStream, readFileSync, readdirSync} from 'fs';
+import {join} from 'path';
+import {type EvaluationQuestionProvider} from '../interface';
+import {config} from './config';
 
 export const getRecordCount = () => 14042;
 
 export const forEachEvaluationQuestion: EvaluationQuestionProvider = async (fn) => {
-  const devFolder = join(config.pathToFolder, 'dev');
-  const testFolder = join(config.pathToFolder, 'test');
+	const devFolder = join(config.pathToFolder, 'dev');
+	const testFolder = join(config.pathToFolder, 'test');
 
-  const devCsvFilenames = readdirSync(devFolder).filter((f) => f.endsWith('.csv'));
-  const testCsvFilenames = readdirSync(testFolder).filter((f) => f.endsWith('.csv'));
+	const devCsvFilenames = readdirSync(devFolder).filter((f) => f.endsWith('.csv'));
+	const testCsvFilenames = readdirSync(testFolder).filter((f) => f.endsWith('.csv'));
 
-  const inTestButMissingDev = testCsvFilenames.filter((t) => !devCsvFilenames.find((d) => getSubjectName(d) === getSubjectName(t)));
-  if (inTestButMissingDev.length > 0) {
-    throw new Error(`Found test file ${inTestButMissingDev[0]} but no corresponding dev file`);
-  }
+	const inTestButMissingDev = testCsvFilenames.filter((t) => !devCsvFilenames.find((d) => getSubjectName(d) === getSubjectName(t)));
+	if (inTestButMissingDev.length > 0) {
+		throw new Error(`Found test file ${inTestButMissingDev[0]} but no corresponding dev file`);
+	}
 
-  return Promise.all(testCsvFilenames.map(async (testCsvFilename) => {
-    const subject = getSubjectName(testCsvFilename);
-    const devCsvFilename = devCsvFilenames.find((d) => getSubjectName(d) === subject);
+	return Promise.all(testCsvFilenames.map(async (testCsvFilename) => {
+		const subject = getSubjectName(testCsvFilename);
+		const devCsvFilename = devCsvFilenames.find((d) => getSubjectName(d) === subject);
 
-    const { data: devRecords } = Papa.parse<string[]>(readFileSync(join(devFolder, devCsvFilename!), { encoding: 'utf-8' }));
+		const {data: devRecords} = Papa.parse<string[]>(readFileSync(join(devFolder, devCsvFilename!), {encoding: 'utf-8'}));
 
-    let count = 0;
-    const promises: Promise<void>[] = [];
-    await new Promise<void>((resolve) => {
-      Papa.parse<string[]>(createReadStream(join(testFolder, testCsvFilename)), {
-        step: (result) => {
-          const questionId = `${subject.replaceAll(' ', '_')}_${count}`;
-          count += 1;
-          const task = parseRecord(result.data);
-          promises.push(fn({
-            id: questionId,
-            prompt: `The following are multiple choice questions (with answers) about ${subject}.
+		let count = 0;
+		const promises: Promise<void>[] = [];
+		await new Promise<void>((resolve) => {
+			Papa.parse<string[]>(createReadStream(join(testFolder, testCsvFilename)), {
+				step(result) {
+					const questionId = `${subject.replaceAll(' ', '_')}_${count}`;
+					count += 1;
+					const task = parseRecord(result.data);
+					promises.push(fn({
+						id: questionId,
+						prompt: `The following are multiple choice questions (with answers) about ${subject}.
 
 ${devRecords.slice(0, 5).map(parseRecord).map(stringifyTask).join('\n\n')}
 
-${stringifyTask({ ...task, answer: undefined })}`,
-            choices: ['A', 'B', 'C', 'D'],
-            answer: task.answer,
-          }));
-        },
-        complete: () => resolve(),
-      });
-    });
-    return Promise.all(promises);
-  })).then(() => {});
+${stringifyTask({...task, answer: undefined})}`,
+						choices: ['A', 'B', 'C', 'D'],
+						answer: task.answer,
+					}));
+				},
+				complete() {
+					resolve();
+				},
+			});
+		});
+		return Promise.all(promises);
+	})).then(() => undefined);
 };
 
 /** @example "high_school_physics_dev.csv" -> "high school physics" */
 const getSubjectName = (csvFilename: string): string => csvFilename.replaceAll(/(dev|test)\.csv$/g, '').replaceAll(/[-_]/g, ' ').replaceAll(/\s+/g, ' ').trim();
 
-interface MMLUTask {
-  question: string,
-  optionA: string,
-  optionB: string,
-  optionC: string,
-  optionD: string,
-  answer: 'A' | 'B' | 'C' | 'D',
-}
+type MMLUTask = {
+	question: string;
+	optionA: string;
+	optionB: string;
+	optionC: string;
+	optionD: string;
+	answer: 'A' | 'B' | 'C' | 'D';
+};
 
 const parseRecord = (record: string[]): MMLUTask => {
-  const [question, optionA, optionB, optionC, optionD, answer] = record;
-  if (!question || !optionA || !optionB || !optionC || !optionD || !answer) {
-    throw new Error('Invalid evaluation question');
-  }
-  if (answer !== 'A' && answer !== 'B' && answer !== 'C' && answer !== 'D') {
-    throw new Error(`Invalid answer for MMLU question: ${answer}`);
-  }
-  return {
-    question, optionA, optionB, optionC, optionD, answer,
-  };
+	const [question, optionA, optionB, optionC, optionD, answer] = record;
+	if (!question || !optionA || !optionB || !optionC || !optionD || !answer) {
+		throw new Error('Invalid evaluation question');
+	}
+
+	if (answer !== 'A' && answer !== 'B' && answer !== 'C' && answer !== 'D') {
+		throw new Error(`Invalid answer for MMLU question: ${answer}`);
+	}
+
+	return {
+		question, optionA, optionB, optionC, optionD, answer,
+	};
 };
 
 // Tries to match format of HELM
-const stringifyTask = (task: Omit<MMLUTask, 'answer'> & { answer: MMLUTask['answer'] | undefined }): string => `Question: ${task.question}
+const stringifyTask = (task: Omit<MMLUTask, 'answer'> & {answer: MMLUTask['answer'] | undefined}): string => `Question: ${task.question}
 A. ${task.optionA}
 B. ${task.optionB}
 C. ${task.optionC}

--- a/src/getAnswer.ts
+++ b/src/getAnswer.ts
@@ -1,30 +1,30 @@
 import pRetry from 'p-retry';
-import { EvaluationQuestion } from './dataset-connectors/interface';
-import { GetCompletion, GetLogProbs } from './model-connectors/interface';
+import {type EvaluationQuestion} from './dataset-connectors/interface';
+import {type GetCompletion, type GetLogProbs} from './model-connectors/interface';
 
 export const getAnswerFromCompletion = async (getCompletion: GetCompletion, question: EvaluationQuestion): Promise<string> => {
-  return pRetry(async () => {
-    const response = (await getCompletion(question.prompt)).trim().replaceAll('.', '');
+	return pRetry(async () => {
+		const response = (await getCompletion(question.prompt)).trim().replaceAll('.', '');
 
-    const selectedAnswer = question.choices.find((choice) => response === choice || response.startsWith(`${choice} `));
+		const selectedAnswer = question.choices.find((choice) => response === choice || response.startsWith(`${choice} `));
 
-    if (!selectedAnswer) {
-      throw new Error(`Model failed to generate response matching possible choice, got ${response} but expected one of ${question.choices}`);
-    }
+		if (!selectedAnswer) {
+			throw new Error(`Model failed to generate response matching possible choice, got ${response} but expected one of ${question.choices.join(', ')}`);
+		}
 
-    return selectedAnswer;
-  });
+		return selectedAnswer;
+	});
 };
 
 export const getAnswerFromLogProbs = async (getLogProbs: GetLogProbs, question: EvaluationQuestion): Promise<string> => {
-  return pRetry(async () => {
-    const tokens = Object.entries(await getLogProbs(question.prompt)).sort((a, b) => b[1] - a[1]).map(([token]) => token.trim());
-    const selectedAnswer = tokens.find((token) => question.choices.includes(token));
+	return pRetry(async () => {
+		const tokens = Object.entries(await getLogProbs(question.prompt)).sort((a, b) => b[1] - a[1]).map(([token]) => token.trim());
+		const selectedAnswer = tokens.find((token) => question.choices.includes(token));
 
-    if (!selectedAnswer) {
-      throw new pRetry.AbortError('Model failed to generate log prob matching possible choice');
-    }
+		if (!selectedAnswer) {
+			throw new pRetry.AbortError('Model failed to generate log prob matching possible choice');
+		}
 
-    return selectedAnswer;
-  });
+		return selectedAnswer;
+	});
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
-import { appendFile, rename, writeFile } from 'fs/promises';
-import { createReadStream, existsSync } from 'fs';
+import {appendFile, rename, writeFile} from 'fs/promises';
+import {createReadStream, existsSync} from 'fs';
 import Papa from 'papaparse';
-import { join } from 'path';
-import { forEachEvaluationQuestion, getRecordCount } from './dataset-connectors/mmlu';
-import { getAnswerFromLogProbs } from './getAnswer';
-import { getLogProbs } from './model-connectors/llama-cpp-python';
-import { EvaluationQuestion } from './dataset-connectors/interface';
-import { addTypo } from './addTypo';
+import {join} from 'path';
+import {forEachEvaluationQuestion, getRecordCount} from './dataset-connectors/mmlu';
+import {getAnswerFromLogProbs} from './getAnswer';
+import {getLogProbs} from './model-connectors/llama-cpp-python';
+import {type EvaluationQuestion} from './dataset-connectors/interface';
+import {addTypo} from './addTypo';
 
 const outputFile = join('outputs', 'output.csv');
 
@@ -16,94 +16,97 @@ type TypoCount = typeof typoCounts[number];
 const makeId = (questionId: string, typoCount: TypoCount) => `${questionId}_${typoCount}`;
 
 const appendCsvLine = async ({
-  questionId, typoCount, prompt, actualAnswer, givenAnswer, error,
+	questionId, typoCount, prompt, actualAnswer, givenAnswer, error,
 }: {
-  questionId: string,
-  typoCount: TypoCount,
-  prompt: string,
-  actualAnswer?: string,
-  givenAnswer?: string,
-  error?: string
+	questionId: string;
+	typoCount: TypoCount;
+	prompt: string;
+	actualAnswer?: string;
+	givenAnswer?: string;
+	error?: string;
 }): Promise<void> => {
-  // eslint-disable-next-line no-nested-ternary
-  const isCorrect = actualAnswer === givenAnswer ? 'TRUE' : (givenAnswer ? 'FALSE' : '');
-  await appendFile(outputFile, `${Papa.unparse([[makeId(questionId, typoCount), questionId, typoCount, prompt, actualAnswer, givenAnswer, isCorrect, error ?? '']])}\n`);
+	const isCorrect = actualAnswer === givenAnswer ? 'TRUE' : (givenAnswer ? 'FALSE' : '');
+	await appendFile(outputFile, `${Papa.unparse([[makeId(questionId, typoCount), questionId, typoCount, prompt, actualAnswer, givenAnswer, isCorrect, error ?? '']])}\n`);
 };
 
 const main = async () => {
-  const completedIds = await findCompletedIds(outputFile);
-  if (completedIds.size === 0) {
-    console.log('Did not find any valid output, creating new output file');
-    if (existsSync(outputFile)) {
-      console.log('Saving previous output.csv to output.csv.bak');
-      await rename(outputFile, `${outputFile}.bak`);
-    }
-    await writeFile(outputFile, 'id,question_id,typoCount,prompt,answer,chosen,isCorrect,error\n');
-  } else {
-    console.log(`Found ${completedIds.size} results already, continuing from where we left off`);
-  }
+	const completedIds = await findCompletedIds(outputFile);
+	if (completedIds.size === 0) {
+		console.log('Did not find any valid output, creating new output file');
+		if (existsSync(outputFile)) {
+			console.log('Saving previous output.csv to output.csv.bak');
+			await rename(outputFile, `${outputFile}.bak`);
+		}
 
-  let count = completedIds.size;
-  let lastUpdate = new Date();
-  const total = getRecordCount() * typoCounts.length;
-  const updateFrequency = 1;
-  await forEachEvaluationQuestion(async (q) => {
-    await Promise.all(typoCounts.map(async (typos) => {
-      if (completedIds.has(makeId(q.id, typos))) {
-        // skip: already run
-        return;
-      }
-      await runQuestion(addTypos(q, typos), typos);
-      count += 1;
-      if (count % updateFrequency === 0 || count === total) {
-        console.log(`[${new Date().toISOString()}] Completed ${count}/${total} (${(100 * (count / total)).toFixed(2)}%) prompts (each: ${((Date.now() - lastUpdate.getTime()) / 1000) / updateFrequency} seconds)`);
-        lastUpdate = new Date();
-      }
-    }));
-  });
+		await writeFile(outputFile, 'id,question_id,typoCount,prompt,answer,chosen,isCorrect,error\n');
+	} else {
+		console.log(`Found ${completedIds.size} results already, continuing from where we left off`);
+	}
+
+	let count = completedIds.size;
+	let lastUpdate = new Date();
+	const total = getRecordCount() * typoCounts.length;
+	const updateFrequency = 1;
+	await forEachEvaluationQuestion(async (q) => {
+		await Promise.all(typoCounts.map(async (typos) => {
+			if (completedIds.has(makeId(q.id, typos))) {
+				// skip: already run
+				return;
+			}
+
+			await runQuestion(addTypos(q, typos), typos);
+			count += 1;
+			if (count % updateFrequency === 0 || count === total) {
+				console.log(`[${new Date().toISOString()}] Completed ${count}/${total} (${(100 * (count / total)).toFixed(2)}%) prompts (each: ${((Date.now() - lastUpdate.getTime()) / 1000) / updateFrequency} seconds)`);
+				lastUpdate = new Date();
+			}
+		}));
+	});
 };
 
 const runQuestion = async (q: EvaluationQuestion, typoCount: TypoCount) => {
-  try {
-    const givenAnswer = await getAnswerFromLogProbs(getLogProbs, q);
-    await appendCsvLine({
-      questionId: q.id, typoCount, prompt: q.prompt, actualAnswer: q.answer, givenAnswer,
-    });
-  } catch (err) {
-    console.error(makeId(q.id, typoCount), err);
-    await appendCsvLine({
-      questionId: q.id, typoCount, prompt: q.prompt, actualAnswer: q.answer, error: err instanceof Error ? err.message : String(err),
-    });
-  }
+	try {
+		const givenAnswer = await getAnswerFromLogProbs(getLogProbs, q);
+		await appendCsvLine({
+			questionId: q.id, typoCount, prompt: q.prompt, actualAnswer: q.answer, givenAnswer,
+		});
+	} catch (err) {
+		console.error(makeId(q.id, typoCount), err);
+		await appendCsvLine({
+			questionId: q.id, typoCount, prompt: q.prompt, actualAnswer: q.answer, error: err instanceof Error ? err.message : String(err),
+		});
+	}
 };
 
 const addTypos = (q: EvaluationQuestion, typos: TypoCount): EvaluationQuestion => {
-  let promptWithTypos = q.prompt;
-  for (let i = 0; i < typos; i++) {
-    promptWithTypos = addTypo(promptWithTypos);
-  }
+	let promptWithTypos = q.prompt;
+	for (let i = 0; i < typos; i++) {
+		promptWithTypos = addTypo(promptWithTypos);
+	}
 
-  return {
-    ...q,
-    prompt: promptWithTypos,
-  };
+	return {
+		...q,
+		prompt: promptWithTypos,
+	};
 };
 
 const findCompletedIds = async (file: string): Promise<Set<string>> => {
-  const set = new Set<string>();
-  await new Promise<void>((resolve) => {
-    Papa.parse<{ id?: unknown }>(createReadStream(file), {
-      header: true,
-      step: (result) => {
-        const { id } = result.data;
-        if (typeof id === 'string' && id.length > 0) {
-          set.add(id);
-        }
-      },
-      complete: () => resolve(),
-    });
-  });
-  return set;
+	const set = new Set<string>();
+	await new Promise<void>((resolve) => {
+		Papa.parse<{id?: unknown}>(createReadStream(file), {
+			header: true,
+			step(result) {
+				const {id} = result.data;
+				if (typeof id === 'string' && id.length > 0) {
+					set.add(id);
+				}
+			},
+			complete() {
+				resolve();
+			},
+		});
+	});
+	return set;
 };
 
-main();
+void main();

--- a/src/model-connectors/interface.ts
+++ b/src/model-connectors/interface.ts
@@ -1,5 +1,5 @@
 export type PromptRole = 'system' | 'user' | 'assistant';
-export type Prompt = { role: PromptRole, content: string }[];
+export type Prompt = {role: PromptRole; content: string}[];
 export type GetChatCompletion = (prompt: Prompt) => Promise<string>;
 export type GetCompletion = (prompt: string) => Promise<string>;
 export type GetLogProbs = (prompt: string) => Promise<Record<string, number>>;

--- a/src/model-connectors/llama-cpp-python/config.ts
+++ b/src/model-connectors/llama-cpp-python/config.ts
@@ -1,5 +1,5 @@
 export const config = {
-  // from empirical testing, increasing this value seems to make no difference on an M2 MacBook
-  requestConcurrency: 1,
-  baseURL: 'http://localhost:8000',
+	// from empirical testing, increasing this value seems to make no difference on an M2 MacBook
+	requestConcurrency: 1,
+	baseURL: 'http://localhost:8000',
 };

--- a/src/model-connectors/llama-cpp-python/index.ts
+++ b/src/model-connectors/llama-cpp-python/index.ts
@@ -1,76 +1,76 @@
 import pLimit from 'p-limit';
 import axios from 'axios';
-import { config } from './config';
-import { GetChatCompletion, GetCompletion, GetLogProbs } from '../interface';
+import {config} from './config';
+import {type GetChatCompletion, type GetCompletion, type GetLogProbs} from '../interface';
 
 const globalRateLimit = pLimit(config.requestConcurrency);
 
-export const getChatCompletion: GetChatCompletion = (messages) => {
-  return globalRateLimit(async () => {
-    const response = await axios({
-      baseURL: config.baseURL,
-      url: '/v1/chat/completions',
-      method: 'post',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      data: {
-        messages,
-        max_tokens: 500,
-      },
-    });
+export const getChatCompletion: GetChatCompletion = async (messages) => {
+	return globalRateLimit(async () => {
+		const response = await axios({
+			baseURL: config.baseURL,
+			url: '/v1/chat/completions',
+			method: 'post',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			data: {
+				messages,
+				max_tokens: 500,
+			},
+		});
 
-    if (response.status < 200 || response.status >= 300) {
-      throw new Error(`HTTP error calling API: got status ${response.status}`);
-    }
+		if (response.status < 200 || response.status >= 300) {
+			throw new Error(`HTTP error calling API: got status ${response.status}`);
+		}
 
-    return response.data.choices[0].message.content;
-  });
+		return response.data.choices[0].message.content;
+	});
 };
 
-export const getCompletion: GetCompletion = (prompt) => {
-  return globalRateLimit(async () => {
-    const response = await axios({
-      baseURL: config.baseURL,
-      url: '/v1/completions',
-      method: 'post',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      data: {
-        prompt,
-        max_tokens: 500,
-      },
-    });
+export const getCompletion: GetCompletion = async (prompt) => {
+	return globalRateLimit(async () => {
+		const response = await axios({
+			baseURL: config.baseURL,
+			url: '/v1/completions',
+			method: 'post',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			data: {
+				prompt,
+				max_tokens: 500,
+			},
+		});
 
-    if (response.status < 200 || response.status >= 300) {
-      throw new Error(`HTTP error calling API: got status ${response.status}`);
-    }
+		if (response.status < 200 || response.status >= 300) {
+			throw new Error(`HTTP error calling API: got status ${response.status}`);
+		}
 
-    return response.data.choices[0].text;
-  });
+		return response.data.choices[0].text;
+	});
 };
 
-export const getLogProbs: GetLogProbs = (prompt) => {
-  return globalRateLimit(async () => {
-    const response = await axios({
-      baseURL: config.baseURL,
-      url: '/v1/completions',
-      method: 'post',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      data: {
-        logprobs: 15,
-        prompt,
-        max_tokens: 1,
-      },
-    });
+export const getLogProbs: GetLogProbs = async (prompt) => {
+	return globalRateLimit(async () => {
+		const response = await axios({
+			baseURL: config.baseURL,
+			url: '/v1/completions',
+			method: 'post',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			data: {
+				logprobs: 15,
+				prompt,
+				max_tokens: 1,
+			},
+		});
 
-    if (response.status < 200 || response.status >= 300) {
-      throw new Error(`HTTP error calling API: got status ${response.status}`);
-    }
+		if (response.status < 200 || response.status >= 300) {
+			throw new Error(`HTTP error calling API: got status ${response.status}`);
+		}
 
-    return response.data.choices[0].logprobs.top_logprobs[0];
-  });
+		return response.data.choices[0].logprobs.top_logprobs[0];
+	});
 };

--- a/src/model-connectors/ollama/config.ts
+++ b/src/model-connectors/ollama/config.ts
@@ -1,5 +1,5 @@
 export const config = {
-  requestConcurrency: 3,
-  baseURL: 'http://localhost:11434',
-  model: process.env['MODEL_OLLAMA_MODEL']!,
+	requestConcurrency: 3,
+	baseURL: 'http://localhost:11434',
+	model: process.env['MODEL_OLLAMA_MODEL']!,
 };

--- a/src/model-connectors/ollama/index.ts
+++ b/src/model-connectors/ollama/index.ts
@@ -1,60 +1,60 @@
 import pLimit from 'p-limit';
 import axios from 'axios';
-import { config } from './config';
-import { GetChatCompletion, GetCompletion } from '../interface';
+import {config} from './config';
+import {type GetChatCompletion, type GetCompletion} from '../interface';
 
 const globalRateLimit = pLimit(config.requestConcurrency);
 
-export const getChatCompletion: GetChatCompletion = (messages) => {
-  return globalRateLimit(async () => {
-    const response = await axios({
-      baseURL: config.baseURL,
-      url: '/api/chat',
-      method: 'post',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      data: {
-        model: config.model,
-        messages,
-        stream: false,
-        options: {
-          num_predict: 1,
-        },
-      },
-    });
+export const getChatCompletion: GetChatCompletion = async (messages) => {
+	return globalRateLimit(async () => {
+		const response = await axios({
+			baseURL: config.baseURL,
+			url: '/api/chat',
+			method: 'post',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			data: {
+				model: config.model,
+				messages,
+				stream: false,
+				options: {
+					num_predict: 1,
+				},
+			},
+		});
 
-    if (response.status < 200 || response.status >= 300) {
-      throw new Error(`HTTP error calling API: got status ${response.status}`);
-    }
+		if (response.status < 200 || response.status >= 300) {
+			throw new Error(`HTTP error calling API: got status ${response.status}`);
+		}
 
-    return response.data.response;
-  });
+		return response.data.response;
+	});
 };
 
-export const getCompletion: GetCompletion = (prompt) => {
-  return globalRateLimit(async () => {
-    const response = await axios({
-      baseURL: config.baseURL,
-      url: '/api/generate',
-      method: 'post',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      data: {
-        model: config.model,
-        prompt,
-        stream: false,
-        options: {
-          num_predict: 1,
-        },
-      },
-    });
+export const getCompletion: GetCompletion = async (prompt) => {
+	return globalRateLimit(async () => {
+		const response = await axios({
+			baseURL: config.baseURL,
+			url: '/api/generate',
+			method: 'post',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			data: {
+				model: config.model,
+				prompt,
+				stream: false,
+				options: {
+					num_predict: 1,
+				},
+			},
+		});
 
-    if (response.status < 200 || response.status >= 300) {
-      throw new Error(`HTTP error calling API: got status ${response.status}`);
-    }
+		if (response.status < 200 || response.status >= 300) {
+			throw new Error(`HTTP error calling API: got status ${response.status}`);
+		}
 
-    return response.data.response;
-  });
+		return response.data.response;
+	});
 };

--- a/src/model-connectors/openai/config.ts
+++ b/src/model-connectors/openai/config.ts
@@ -1,6 +1,6 @@
 export const config = {
-  requestConcurrency: 3,
-  apiKey: process.env['MODEL_OPENAI_API_KEY']!,
-  organization: process.env['MODEL_OPENAI_ORG']!,
-  model: process.env['MODEL_OPENAI_MODEL']!,
+	requestConcurrency: 3,
+	apiKey: process.env['MODEL_OPENAI_API_KEY']!,
+	organization: process.env['MODEL_OPENAI_ORG']!,
+	model: process.env['MODEL_OPENAI_MODEL']!,
 };

--- a/src/model-connectors/openai/index.ts
+++ b/src/model-connectors/openai/index.ts
@@ -1,31 +1,31 @@
 import pLimit from 'p-limit';
 import axios from 'axios';
-import { config } from './config';
-import { GetChatCompletion } from '../interface';
+import {config} from './config';
+import {type GetChatCompletion} from '../interface';
 
 const globalRateLimit = pLimit(config.requestConcurrency);
 
-export const getChatCompletion: GetChatCompletion = (messages) => {
-  return globalRateLimit(async () => {
-    const response = await axios({
-      url: 'https://api.openai.com/v1/chat/completions',
-      method: 'post',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${config.apiKey}`,
-        'OpenAI-Organization': config.organization,
-      },
-      data: {
-        model: config.model,
-        messages,
-        max_tokens: 500,
-      },
-    });
+export const getChatCompletion: GetChatCompletion = async (messages) => {
+	return globalRateLimit(async () => {
+		const response = await axios({
+			url: 'https://api.openai.com/v1/chat/completions',
+			method: 'post',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${config.apiKey}`,
+				'OpenAI-Organization': config.organization,
+			},
+			data: {
+				model: config.model,
+				messages,
+				max_tokens: 500,
+			},
+		});
 
-    if (response.status < 200 || response.status >= 300) {
-      throw new Error(`HTTP error calling API: got status ${response.status}`);
-    }
+		if (response.status < 200 || response.status >= 300) {
+			throw new Error(`HTTP error calling API: got status ${response.status}`);
+		}
 
-    return response.data.choices[0].message.content;
-  });
+		return response.data.choices[0].message.content;
+	});
 };


### PR DESCRIPTION
Migrates the repo from `eslint-config-domdomegg` v1 (legacy `eslintConfig` in package.json) to v2's flat config.

## Changes
- Bump `eslint-config-domdomegg` to `^2.0.9` and `eslint` to `^9.0.0`.
- Remove the legacy `eslintConfig` key from package.json and add a flat `eslint.config.mjs` spreading `...domdomegg`.
- Simplify the lint script to `eslint` (flat config discovers files itself).
- Reformat all sources to the preset's style via `eslint --fix` (spaces → tabs). **The large source diff is entirely mechanical reindentation — no logic changes.**

## Non-mechanical fixes (v2 rules are stricter than v1)
Four tiny, behaviour-preserving fixes were needed to get a clean pass — none are rule suppressions:
- `src/addTypo.ts`: drop the now-unnecessary `default` case from an exhaustive `switch` (`switch-exhaustiveness-check`); this also removes the `${typoType satisfies never}` template that tripped `restrict-template-expressions`.
- `src/getAnswer.ts`: `${question.choices}` → `${question.choices.join(', ')}` (`restrict-template-expressions` — a `string[]` in a template).
- `src/index.ts`: `main()` → `void main()` (`no-floating-promises`).
- `src/dataset-connectors/mmlu/index.ts`: `.then(() => {})` → `.then(() => undefined)` (`no-empty-function`).

## Status
- Lint: clean (`npx eslint`, exit 0).
- Build: passes (`npm run build`).
- Tests: all 8 pass (`npm test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)